### PR TITLE
Add rolling window option and cointegration filter

### DIFF
--- a/pairs/pair_analysis.py
+++ b/pairs/pair_analysis.py
@@ -70,7 +70,7 @@ def apply_kalman_filter(y, X):
     
     return states_pred, covs_pred
 
-def calculate_spread_and_zscore(y, X, states):
+def calculate_spread_and_zscore(y, X, states, rolling_window=20):
     """
     Calculate the spread (y - beta*X) and its rolling Z-score.
 
@@ -78,6 +78,8 @@ def calculate_spread_and_zscore(y, X, states):
         y (pd.Series): The first time series.
         X (pd.Series): The second time series.
         states (np.ndarray): The estimated states (alpha, beta) from Kalman Filter.
+        rolling_window (int, optional): Window size for rolling statistics used
+            when computing the Z-score. Defaults to 20.
 
     Returns:
         pd.Series: The rolling Z-score of the spread.
@@ -94,7 +96,6 @@ def calculate_spread_and_zscore(y, X, states):
     spread = aligned_y - aligned_states_beta * aligned_X
     
     # Calculate rolling mean and standard deviation of the spread
-    rolling_window = 20
     rolling_mean = spread.rolling(window=rolling_window).mean()
     rolling_std = spread.rolling(window=rolling_window).std()
     


### PR DESCRIPTION
## Summary
- add `rolling_window` parameter to `calculate_spread_and_zscore`
- use that parameter from `run_engine.py`
- filter pairs by cointegration p-value

## Testing
- `python -m py_compile pairs/pair_analysis.py run_engine.py`

------
https://chatgpt.com/codex/tasks/task_e_6846dbb33d648332ae6f34ea49834d0d