### PR TITLE
Handle yfinance errors gracefully

### DIFF
--- a/data/fetch_data.py
+++ b/data/fetch_data.py
@@ -1,6 +1,11 @@
 import yfinance as yf
 import pandas as pd
 
+
+class DataFetchError(Exception):
+    """Custom exception for data fetching errors."""
+    pass
+
 def fetch_etf_data(tickers, start_date, end_date):
     """
     Fetches historical adjusted close price data for a list of ETF tickers.
@@ -14,7 +19,13 @@ def fetch_etf_data(tickers, start_date, end_date):
         pandas.DataFrame: A DataFrame with adjusted close prices indexed by date.
     """
     # Download data with auto_adjust=True to get adjusted prices
-    data = yf.download(tickers, start=start_date, end=end_date, auto_adjust=True)
+    try:
+        data = yf.download(tickers, start=start_date, end=end_date, auto_adjust=True)
+    except Exception as e:
+        raise DataFetchError(f"Failed to download data for {tickers}: {e}")
+
+    if data.empty:
+        raise DataFetchError("Downloaded data is empty. Please check ticker symbols or network connection.")
     
     # If multiple tickers, data will have a MultiIndex columns
     if isinstance(tickers, list) and len(tickers) > 1:

--- a/run_engine.py
+++ b/run_engine.py
@@ -3,7 +3,8 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 # Import modules
-from data.fetch_data import fetch_etf_data
+from data.fetch_data import fetch_etf_data, DataFetchError
+import sys
 from pairs.pair_analysis import calculate_cointegration, apply_kalman_filter, calculate_spread_and_zscore
 from regime.regime_detection import calculate_volatility, train_hmm, predict_regimes
 from backtest import (
@@ -30,8 +31,17 @@ STABLE_REGIME_INDEX = 0
 
 # --- Data Fetching ---
 print(f"Fetching data for {ETF_TICKERS}...")
-data = fetch_etf_data(ETF_TICKERS, START_DATE, END_DATE)
-data = data.dropna(axis=1, thresh=int(0.9 * len(data)))
+try:
+    data = fetch_etf_data(ETF_TICKERS, START_DATE, END_DATE)
+    data = data.dropna(axis=1, thresh=int(0.9 * len(data)))
+except DataFetchError as e:
+    print(f"Data fetch failed: {e}")
+    sys.exit(1)
+
+if data.empty:
+    print("No data returned from data source. Exiting.")
+    sys.exit(1)
+
 print("Data fetched successfully.")
 print("Available tickers:", data.columns.tolist())
 


### PR DESCRIPTION
## Summary
- wrap yfinance download in a try/except and raise a custom `DataFetchError`
- exit `run_engine.py` cleanly when data can't be fetched

## Testing
- `python -m py_compile data/fetch_data.py run_engine.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846dbb7efb483329f995d8ab97682b5