### PR TITLE
Update spread calculation and cointegration filter

### DIFF
--- a/pairs/pair_analysis.py
+++ b/pairs/pair_analysis.py
@@ -70,7 +70,7 @@ def apply_kalman_filter(y, X):
     
     return states_pred, covs_pred
 
-def calculate_spread_and_zscore(y, X, states):
+def calculate_spread_and_zscore(y, X, states, rolling_window: int = 20):
     """
     Calculate the spread (y - beta*X) and its rolling Z-score.
 
@@ -94,7 +94,6 @@ def calculate_spread_and_zscore(y, X, states):
     spread = aligned_y - aligned_states_beta * aligned_X
     
     # Calculate rolling mean and standard deviation of the spread
-    rolling_window = 20
     rolling_mean = spread.rolling(window=rolling_window).mean()
     rolling_std = spread.rolling(window=rolling_window).std()
     

--- a/run_engine.py
+++ b/run_engine.py
@@ -79,12 +79,25 @@ for i in range(len(data.columns)):
         price_y_aligned = aligned_prices.iloc[:, 0]
         price_X_aligned = aligned_prices.iloc[:, 1]
 
+        # Check for cointegration and skip pair if not cointegrated
+        _, coint_p, _ = calculate_cointegration(price_y_aligned, price_X_aligned)
+        if coint_p is None or coint_p > 0.05:
+            print(
+                f"Skipping pair {asset1_ticker}-{asset2_ticker}: p-value {coint_p} exceeds threshold."
+            )
+            continue
+
         # Apply Kalman Filter
         # Note: Kalman filter needs input shaped (n_samples, n_features)
         kf_states, kf_covs = apply_kalman_filter(price_y_aligned, price_X_aligned)
 
         # Calculate Spread and Z-score
-        z_score = calculate_spread_and_zscore(price_y_aligned, price_X_aligned, kf_states)
+        z_score = calculate_spread_and_zscore(
+            price_y_aligned,
+            price_X_aligned,
+            kf_states,
+            rolling_window=ZSCORE_WINDOW,
+        )
 
         # Store pair data
         pairs_data[(asset1_ticker, asset2_ticker)] = {


### PR DESCRIPTION
## Summary
- support a configurable rolling window in `calculate_spread_and_zscore`
- use that window when running the engine
- filter pairs by cointegration p-value before running the Kalman filter

## Testing
- `python -m py_compile pairs/pair_analysis.py run_engine.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846ec6f2eb483328af1c2c9ff8fac44