### PR TITLE
Improve data fetch error handling

### DIFF
--- a/data/fetch_data.py
+++ b/data/fetch_data.py
@@ -1,6 +1,11 @@
 import yfinance as yf
 import pandas as pd
 
+
+class DataFetchError(Exception):
+    """Raised when fetching data from the API fails."""
+    pass
+
 def fetch_etf_data(tickers, start_date, end_date):
     """
     Fetches historical adjusted close price data for a list of ETF tickers.
@@ -14,7 +19,13 @@ def fetch_etf_data(tickers, start_date, end_date):
         pandas.DataFrame: A DataFrame with adjusted close prices indexed by date.
     """
     # Download data with auto_adjust=True to get adjusted prices
-    data = yf.download(tickers, start=start_date, end=end_date, auto_adjust=True)
+    try:
+        data = yf.download(tickers, start=start_date, end=end_date, auto_adjust=True)
+    except Exception as e:
+        raise DataFetchError(f"Failed to download data: {e}")
+
+    if data.empty:
+        return pd.DataFrame()
     
     # If multiple tickers, data will have a MultiIndex columns
     if isinstance(tickers, list) and len(tickers) > 1:

--- a/run_engine.py
+++ b/run_engine.py
@@ -1,9 +1,10 @@
 import pandas as pd
 import numpy as np
 import matplotlib.pyplot as plt
+import sys
 
 # Import modules
-from data.fetch_data import fetch_etf_data
+from data.fetch_data import fetch_etf_data, DataFetchError
 from pairs.pair_analysis import calculate_cointegration, apply_kalman_filter, calculate_spread_and_zscore
 from regime.regime_detection import calculate_volatility, train_hmm, predict_regimes
 from backtest import (
@@ -30,7 +31,16 @@ STABLE_REGIME_INDEX = 0
 
 # --- Data Fetching ---
 print(f"Fetching data for {ETF_TICKERS}...")
-data = fetch_etf_data(ETF_TICKERS, START_DATE, END_DATE)
+try:
+    data = fetch_etf_data(ETF_TICKERS, START_DATE, END_DATE)
+except DataFetchError as e:
+    print(f"Data fetch failed: {e}")
+    sys.exit(1)
+
+if data.empty:
+    print("No data available. Exiting.")
+    sys.exit(1)
+
 data = data.dropna(axis=1, thresh=int(0.9 * len(data)))
 print("Data fetched successfully.")
 print("Available tickers:", data.columns.tolist())


### PR DESCRIPTION
## Summary
- wrap `yf.download` in try/except and raise custom `DataFetchError`
- check for empty results in `fetch_etf_data`
- handle `DataFetchError` in `run_engine.py` and exit gracefully

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846ec73ac088332ac49a8bd96c4298d