### PR TITLE
Fix NaN volatility handling

### DIFF
--- a/backtest/backtest.py
+++ b/backtest/backtest.py
@@ -53,7 +53,11 @@ class PairsBacktest:
         # Calculate pair volatility (20-day rolling)
         pair_vol = (returns1 - returns2).rolling(20).std() * np.sqrt(252)
         current_vol = pair_vol.iloc[-1]
-        
+
+        if pd.isna(current_vol):
+            logger.warning(f"Volatility is NaN for pair {pair}")
+            return 0
+
         if current_vol == 0:
             logger.warning(f"Zero volatility detected for pair {pair}")
             return 0


### PR DESCRIPTION
## Summary
- guard against NaN volatility in `calculate_position_size`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6847fadb0e288332b3054a0e501eba06