### PR TITLE
Fix double equity updates in backtest

### DIFF
--- a/backtest/backtest.py
+++ b/backtest/backtest.py
@@ -115,14 +115,7 @@ class PairsBacktest:
                     if self._should_enter_position(pair, signal, regimes.loc[date]):
                         self._open_position(pair, date, prices.loc[date], signal)
             
-            # Update equity curve with realized and unrealized P&L
-            idx = self.equity_curve.index.get_loc(date)
-            daily_pnl = self.realized_pnl.loc[date] + self._calculate_daily_pnl(date)
-            if idx > 0:
-                prev_date = self.equity_curve.index[idx - 1]
-                self.equity_curve.loc[date] = self.equity_curve.loc[prev_date] + daily_pnl
-            else:
-                self.equity_curve.loc[date] = self.config.initial_capital + daily_pnl
+            # Equity curve is updated within _update_positions to avoid double counting
 
         # Calculate daily returns
         self.daily_returns = self.equity_curve.pct_change()


### PR DESCRIPTION
## Summary
- ensure `run_backtest` relies on `_update_positions` for equity updates

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684854f5d44883328325abd26e76d8bf