### PR TITLE
Add test runner and setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,22 @@ meanr_engine/
 └── README.md
 ```
 
+## Running Tests
+
+Install the project dependencies if you have not already:
+
+```bash
+pip install -r requirements.txt
+```
+
+Then execute the bundled test runner from the repository root:
+
+```bash
+./scripts/run_tests.sh
+```
+
+This script adds the project root to `PYTHONPATH` before invoking `pytest`.
+
 ## Configuration
 
 Key parameters can be adjusted in `run_engine.py`:

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Simple test runner that sets PYTHONPATH to the repository root
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+export PYTHONPATH="$ROOT_DIR:$PYTHONPATH"
+pytest "$@"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+# Ensure the repository root is on the Python path
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))


### PR DESCRIPTION
## Summary
- add a simple test runner that puts the repo on PYTHONPATH
- load repo root in tests
- document how to install requirements and run tests

## Testing
- `./scripts/run_tests.sh -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684993bbba28833286f78c8e297e8a95