### PR TITLE
Use logging instead of prints

### DIFF
--- a/pairs/pair_analysis.py
+++ b/pairs/pair_analysis.py
@@ -2,6 +2,9 @@ import pandas as pd
 import numpy as np
 import statsmodels.tsa.stattools as ts
 from pykalman import KalmanFilter
+import logging
+
+logger = logging.getLogger(__name__)
 
 def calculate_cointegration(series1, series2):
     """
@@ -24,7 +27,7 @@ def calculate_cointegration(series1, series2):
         result = ts.coint(aligned_series.iloc[:, 0], aligned_series.iloc[:, 1])
         return result[0], result[1], result[2]
     except Exception as e:
-        print(f"Error calculating cointegration: {e}")
+        logger.error("Error calculating cointegration: %s", e)
         return None, None, None
 
 def apply_kalman_filter(y, X):

--- a/run_engine.py
+++ b/run_engine.py
@@ -289,12 +289,19 @@ combined_daily_returns = backtest.daily_returns
 all_trades = backtest.trades
 metrics = overall_metrics
 
-print(f"Total trades: {len(all_trades)}")
-print(f"Closed trades: {len([t for t in all_trades if t.exit_date is not None])}")
-print(f"Nonzero daily returns: {(combined_daily_returns != 0).sum()}")
-print(f"Equity curve min/max: {combined_equity_curve.min()}, {combined_equity_curve.max()}")
-print(combined_equity_curve.head(10))
-print(combined_daily_returns.head(10))
+logger.info("Total trades: %s", len(all_trades))
+logger.info(
+    "Closed trades: %s",
+    len([t for t in all_trades if t.exit_date is not None]),
+)
+logger.info("Nonzero daily returns: %s", (combined_daily_returns != 0).sum())
+logger.info(
+    "Equity curve min/max: %s, %s",
+    combined_equity_curve.min(),
+    combined_equity_curve.max(),
+)
+logger.debug(combined_equity_curve.head(10))
+logger.debug(combined_daily_returns.head(10))
 
 # --- Generate Performance Reports ---
 logger.info("Generating performance reports...")


### PR DESCRIPTION
## Summary
- log trading summary metrics in `run_engine.py`
- convert cointegration error print to a log message

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6849a66592d083328173ffb53b70ba9d