### PR TITLE
Improve test instructions and scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ source venv/bin/activate  # On Windows: .\venv\Scripts\activate
 pip install -r requirements.txt
 ```
 
+The list includes core packages such as `hmmlearn` and `pykalman` which are
+required for regime detection and Kalman filtering.
+
 ## Usage
 
 Run the main engine:
@@ -75,11 +78,14 @@ meanr_engine/
 
 ## Running Tests
 
-Install the project dependencies if you have not already:
+Before running the tests, ensure all dependencies are installed:
 
 ```bash
 pip install -r requirements.txt
 ```
+
+Running `pytest` or the helper script without these packages (e.g. `hmmlearn`,
+`pykalman`) will result in import errors.
 
 Then execute the bundled test runner from the repository root:
 

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -2,4 +2,22 @@
 # Simple test runner that sets PYTHONPATH to the repository root
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 export PYTHONPATH="$ROOT_DIR:$PYTHONPATH"
+
+# Warn if key packages are missing
+missing=()
+for pkg in hmmlearn pykalman; do
+    python - <<EOF
+import importlib.util, sys
+sys.exit(0 if importlib.util.find_spec("$pkg") else 1)
+EOF
+    if [ $? -ne 0 ]; then
+        missing+=("$pkg")
+    fi
+done
+
+if [ ${#missing[@]} -ne 0 ]; then
+    echo "WARNING: Missing packages: ${missing[*]}"
+    echo "Run 'pip install -r requirements.txt' first."
+fi
+
 pytest "$@"


### PR DESCRIPTION
## Summary
- document that `hmmlearn`, `pykalman` and other dependencies must be installed
- remind users to `pip install -r requirements.txt` before running tests
- warn about missing packages in `run_tests.sh`

## Testing
- `./scripts/run_tests.sh` *(fails: ModuleNotFoundError for pandas and numpy)*

------
https://chatgpt.com/codex/tasks/task_e_684aa243aad083328bf86f588a9cd3ae