### PR TITLE
Use yaml.safe_load in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ pip install -r requirements.txt
 ```
 
 The list includes core packages such as `hmmlearn` and `pykalman` which are
-required for regime detection and Kalman filtering.
+required for regime detection and Kalman filtering. `PyYAML` is also included
+so the engine can parse the `config.yaml` file using a safe YAML loader.
 
 ## Usage
 
@@ -97,7 +98,9 @@ This script adds the project root to `PYTHONPATH` before invoking `pytest`.
 
 ## Configuration
 
-Key parameters can be adjusted in `run_engine.py`:
+Configuration parameters are stored in `config.yaml` and loaded with
+`PyYAML`'s safe loader. Key settings can also be adjusted directly in
+`run_engine.py`:
 - ETF tickers
 - Date range
 - Cointegration window

--- a/config.py
+++ b/config.py
@@ -1,13 +1,13 @@
-import json
+import yaml
 from pathlib import Path
 
 
 def load_config(path: str = "config.yaml") -> dict:
     """Load configuration from a YAML/JSON file.
 
-    The parser expects the file to contain JSON-formatted data, which is a
-    subset of YAML. This avoids the need for external YAML libraries.
+    Uses ``yaml.safe_load`` so standard YAML features like comments are
+    supported.
     """
     config_path = Path(path)
     with config_path.open("r") as f:
-        return json.load(f)
+        return yaml.safe_load(f)

--- a/config.yaml
+++ b/config.yaml
@@ -1,3 +1,4 @@
+# Configuration for Mean Reversion Engine
 {
   "ETF_TICKERS": ["SPY", "QQQ", "IWM", "EFA", "EMB", "GLD", "SLV", "USO", "TLT", "IEF", "XOM", "CVX", "SLB", "HAL", "MPC", "VLO", "COP", "EOG", "DVN", "ET", "EPD", "OXY", "MRO"],
   "START_DATE": "2020-01-01",

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,5 @@ numba>=0.57.0
 # Additional useful libraries
 scikit-learn>=1.0.0  # For machine learning models and feature engineering
 ta>=0.10.0  # Technical analysis indicators (pure Python implementation)
-tqdm>=4.65.0  # Progress bars for long-running operations 
+tqdm>=4.65.0  # Progress bars for long-running operations
+PyYAML>=6.0


### PR DESCRIPTION
## Summary
- switch config loader to yaml.safe_load
- add PyYAML dependency
- note YAML parsing in README
- allow YAML-style comments in config

## Testing
- `./scripts/run_tests.sh` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684ab64f97e88332b7880cd8e656214e