### PR TITLE
Switch to yaml for config parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,9 @@ settings.
 Example snippet:
 
 ```yaml
-ETF_TICKERS: ["XOM", "CVX"]
+ETF_TICKERS:
+  - XOM
+  - CVX
 PAIR_PARAMS:
   XOM_CVX:
     entry_threshold: 1.8

--- a/config.py
+++ b/config.py
@@ -1,13 +1,12 @@
-import json
+import yaml
 from pathlib import Path
 
 
 def load_config(path: str = "config.yaml") -> dict:
-    """Load configuration from a YAML/JSON file.
+    """Load configuration from a YAML file.
 
-    The parser expects the file to contain JSON-formatted data, which is a
-    subset of YAML. This avoids the need for external YAML libraries.
+    Uses ``yaml.safe_load`` to fully support standard YAML syntax.
     """
     config_path = Path(path)
     with config_path.open("r") as f:
-        return json.load(f)
+        return yaml.safe_load(f)

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,8 @@ pykalman>=0.9.5
 hmmlearn>=0.3.0
 quantstats>=0.0.59
 numba>=0.57.0
+# YAML parsing
+pyyaml>=6.0
 # Additional useful libraries
 scikit-learn>=1.0.0  # For machine learning models and feature engineering
 ta>=0.10.0  # Technical analysis indicators (pure Python implementation)


### PR DESCRIPTION
## Summary
- use `yaml.safe_load` in configuration loader
- add PyYAML dependency
- show YAML-style example in README

## Testing
- `./scripts/run_tests.sh` *(fails: ModuleNotFoundError: pandas, numpy)*

------
https://chatgpt.com/codex/tasks/task_e_684ad02a146083328bc9c1494f81bdb9