### PR TITLE
Add CLI args for run_engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,15 @@ required for regime detection and Kalman filtering.
 
 Run the main engine:
 ```bash
-python run_engine.py
+python run_engine.py --config config.yaml
 ```
 
-This will:
+Optional flags include:
+
+- `--config PATH` - path to the configuration file (defaults to `config.yaml`)
+- `--live` - enable live trading mode (placeholder)
+
+Running the engine will:
 1. Fetch ETF data
 2. Detect market regimes
 3. Generate trading signals

--- a/run_engine.py
+++ b/run_engine.py
@@ -3,6 +3,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 import logging
 import json
+import argparse
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
@@ -493,5 +494,17 @@ def main(config_path="config.yaml"):
     # Implement signal heatmap, better performance reporting.
 
 if __name__ == "__main__":
-    main()
+    parser = argparse.ArgumentParser(description="Run the mean reversion engine")
+    parser.add_argument(
+        "--config",
+        default="config.yaml",
+        help="Path to configuration file",
+    )
+    parser.add_argument(
+        "--live",
+        action="store_true",
+        help="Run in live trading mode",
+    )
+    args = parser.parse_args()
+    main(args.config)
 


### PR DESCRIPTION
## Summary
- add argument parser with `--config` and `--live` flags
- update README usage docs

## Testing
- `./scripts/run_tests.sh` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684ad02a0a508332bb4b1dcd9b666d5a