### PR TITLE
Add grid search optimization utility

### DIFF
--- a/optimization/grid_search.py
+++ b/optimization/grid_search.py
@@ -1,0 +1,71 @@
+import itertools
+from dataclasses import replace
+from typing import Iterable, Dict, Tuple
+
+import pandas as pd
+
+from backtest.backtest import PairsBacktest, BacktestConfig
+
+
+def grid_search(
+    prices: pd.DataFrame,
+    signals: Dict[Tuple[str, str], pd.DataFrame],
+    regimes: pd.Series,
+    entry_thresholds: Iterable[float],
+    exit_thresholds: Iterable[float],
+    stop_loss_ks: Iterable[float],
+    base_config: BacktestConfig | None = None,
+) -> pd.DataFrame:
+    """Run a grid search over the provided parameter ranges.
+
+    Parameters
+    ----------
+    prices : pd.DataFrame
+        Price data for the assets in each pair.
+    signals : dict
+        Mapping of pair tuples to DataFrame signals.
+    regimes : pd.Series
+        Regime series used by the backtester.
+    entry_thresholds, exit_thresholds, stop_loss_ks : iterable of float
+        Parameter ranges to evaluate.
+    base_config : BacktestConfig, optional
+        Base configuration used as a template. Defaults to ``BacktestConfig()``.
+
+    Returns
+    -------
+    pd.DataFrame
+        DataFrame containing performance metrics for each parameter
+        combination, sorted by Sharpe ratio.
+    """
+    if base_config is None:
+        base_config = BacktestConfig()
+
+    results = []
+    for entry_t, exit_t, sl_k in itertools.product(
+        entry_thresholds, exit_thresholds, stop_loss_ks
+    ):
+        cfg = replace(
+            base_config,
+            zscore_entry_threshold=entry_t,
+            zscore_exit_threshold=exit_t,
+            stop_loss_k=sl_k,
+        )
+        bt = PairsBacktest(cfg)
+        bt.run_backtest(prices, signals, regimes)
+        metrics = bt.get_performance_metrics()
+        metrics.update(
+            {
+                "entry_threshold": entry_t,
+                "exit_threshold": exit_t,
+                "stop_loss_k": sl_k,
+            }
+        )
+        results.append(metrics)
+
+    if not results:
+        return pd.DataFrame()
+
+    df = pd.DataFrame(results)
+    if "sharpe_ratio" in df.columns:
+        df = df.sort_values("sharpe_ratio", ascending=False)
+    return df.reset_index(drop=True)

--- a/tests/test_grid_search.py
+++ b/tests/test_grid_search.py
@@ -1,0 +1,44 @@
+import pandas as pd
+import numpy as np
+
+from backtest.backtest import BacktestConfig
+from optimization.grid_search import grid_search
+
+
+def make_data():
+    dates = pd.date_range("2020-01-01", periods=25)
+    prices = pd.DataFrame(
+        {
+            "A": np.linspace(100, 120, 25),
+            "B": np.linspace(101, 121, 25) + np.random.normal(0, 0.5, 25),
+        },
+        index=dates,
+    )
+    signals = {
+        ("A", "B"): pd.DataFrame(
+            {
+                "entry_long": [False] * 20 + [True] + [False] * 4,
+                "entry_short": [False] * 25,
+                "exit": [False] * 21 + [True] + [False] * 3,
+                "stop_loss_k": [2.0] * 25,
+            },
+            index=dates,
+        )
+    }
+    regimes = pd.Series(index=dates, data=0)
+    return prices, signals, regimes
+
+
+def test_grid_search_runs():
+    prices, signals, regimes = make_data()
+    result = grid_search(
+        prices,
+        signals,
+        regimes,
+        entry_thresholds=[1.5, 2.0],
+        exit_thresholds=[0.1],
+        stop_loss_ks=[2.0],
+        base_config=BacktestConfig(slippage_bps=0.0, commission_bps=0.0),
+    )
+    assert not result.empty
+    assert {"entry_threshold", "exit_threshold", "stop_loss_k"}.issubset(result.columns)


### PR DESCRIPTION
## Summary
- add new `optimization` package
- implement `grid_search` function for brute force parameter search
- demonstrate usage with `test_grid_search`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684ad02a1af48332b4865fc5b8c1811c