### PR TITLE
Add pytest requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,9 @@ Before running the tests, ensure all dependencies are installed:
 pip install -r requirements.txt
 ```
 
+The `requirements.txt` file includes `pytest>=8.0`, which provides the test
+runner used by the `scripts/run_tests.sh` helper.
+
 Running `pytest` or the helper script without these packages (e.g. `hmmlearn`,
 `pykalman`) will result in import errors.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,5 @@ pyyaml>=6.0
 # Additional useful libraries
 scikit-learn>=1.0.0  # For machine learning models and feature engineering
 ta>=0.10.0  # Technical analysis indicators (pure Python implementation)
-tqdm>=4.65.0  # Progress bars for long-running operations 
+tqdm>=4.65.0  # Progress bars for long-running operations
+pytest>=8.0  # Required for running the test suite


### PR DESCRIPTION
## Summary
- add pytest>=8.0 to requirements
- document pytest requirement in README

## Testing
- `./scripts/run_tests.sh` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684ad46c751883329e2ff60b2574eaec