### PR TITLE
Update .gitignore for pytest cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ env/
 *.log
 *.png
 *.pdf 
+
+# Test cache
+.pytest_cache/


### PR DESCRIPTION
## Summary
- avoid committing pytest cache by ignoring `.pytest_cache/`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684ad46daa508332a010a3a7453647d6