### PR TITLE
Parse backtest config from YAML

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,12 +1,16 @@
 import yaml
 from pathlib import Path
+from backtest import BacktestConfig
 
 
 def load_config(path: str = "config.yaml") -> dict:
-    """Load configuration from a YAML file.
+    """Load configuration from a YAML file and parse nested sections."""
 
-    Uses ``yaml.safe_load`` to fully support standard YAML syntax.
-    """
     config_path = Path(path)
     with config_path.open("r") as f:
-        return yaml.safe_load(f)
+        cfg = yaml.safe_load(f)
+
+    backtest_cfg = cfg.get("backtest", {}) or {}
+    cfg["backtest"] = BacktestConfig(**backtest_cfg)
+
+    return cfg

--- a/config.yaml
+++ b/config.yaml
@@ -83,3 +83,13 @@ PAIR_PARAMS:
     entry_threshold: 2.2
     exit_threshold: 0.8
     stop_loss_k: 2.1
+
+# Configuration for the backtester
+backtest:
+  initial_capital: 1000000
+  target_volatility: 0.1
+  slippage_bps: 2.0
+  commission_bps: 1.0
+  stop_loss_k: 2.0
+  zscore_entry_threshold: 2.0
+  zscore_exit_threshold: 0.1

--- a/run_engine.py
+++ b/run_engine.py
@@ -260,15 +260,9 @@ def main(config_path="config.yaml"):
     
     # --- Run Backtest ---
     logger.info("Running backtest across all pairs...")
-    config = BacktestConfig(
-        initial_capital=1_000_000,
-        target_volatility=0.10,
-        slippage_bps=2.0,
-        commission_bps=1.0,
-        stop_loss_k=2.0,
-        zscore_entry_threshold=2.0,
-        zscore_exit_threshold=0.1
-    )
+    config = cfg.get("backtest", BacktestConfig())
+    if isinstance(config, dict):
+        config = BacktestConfig(**config)
     
     # Codex's improved loop: run backtest per pair and aggregate
     pair_results = []


### PR DESCRIPTION
## Summary
- add backtest options to `config.yaml`
- convert the `backtest` section to `BacktestConfig` in `load_config`
- construct `BacktestConfig` from YAML in `run_engine`

## Testing
- `pytest -q` *(fails: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684adac8d434833291715431adc1e066