### PR TITLE
Remove unused live trading flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,6 @@ python run_engine.py --config config.yaml
 Optional flags include:
 
 - `--config PATH` - path to the configuration file (defaults to `config.yaml`)
-- `--live` - enable live trading mode (placeholder)
 
 Running the engine will:
 1. Fetch ETF data

--- a/run_engine.py
+++ b/run_engine.py
@@ -506,11 +506,6 @@ if __name__ == "__main__":
         default="config.yaml",
         help="Path to configuration file",
     )
-    parser.add_argument(
-        "--live",
-        action="store_true",
-        help="Run in live trading mode",
-    )
     args = parser.parse_args()
     main(args.config)
 


### PR DESCRIPTION
## Summary
- delete unused `--live` argument from the command line
- clean up README CLI option

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for pandas and numpy)*

------
https://chatgpt.com/codex/tasks/task_e_684adacb35f88332b49114e2af205837