### PR TITLE
Enable parameter-sensitive grid search

### DIFF
--- a/optimization/grid_search.py
+++ b/optimization/grid_search.py
@@ -1,15 +1,50 @@
 import itertools
 from dataclasses import replace
-from typing import Iterable, Dict, Tuple
+from typing import Iterable, Dict, Tuple, Callable
 
 import pandas as pd
 
 from backtest.backtest import PairsBacktest, BacktestConfig
 
 
+def generate_signals(
+    prices: pd.DataFrame,
+    regimes: pd.Series,
+    entry_threshold: float,
+    exit_threshold: float,
+    stop_loss_k: float,
+) -> Dict[Tuple[str, str], pd.DataFrame]:
+    """Generate simple trading signals for a single pair using Z-score."""
+    asset1, asset2 = prices.columns[:2]
+    spread = prices[asset1] - prices[asset2]
+    rolling_mean = spread.rolling(5).mean()
+    rolling_std = spread.rolling(5).std()
+    z_score = (spread - rolling_mean) / rolling_std
+    z_score = z_score.fillna(0.0)
+
+    entry_long = z_score < -entry_threshold
+    entry_short = z_score > entry_threshold
+    exit_signal = z_score.abs() < exit_threshold
+
+    signals = pd.DataFrame(
+        {
+            "entry_long": entry_long,
+            "entry_short": entry_short,
+            "exit": exit_signal,
+            "stop_loss_k": stop_loss_k,
+        },
+        index=prices.index,
+    )
+
+    return {(asset1, asset2): signals}
+
+
 def grid_search(
     prices: pd.DataFrame,
-    signals: Dict[Tuple[str, str], pd.DataFrame],
+    signal_func: Callable[
+        [pd.DataFrame, pd.Series, float, float, float],
+        Dict[Tuple[str, str], pd.DataFrame],
+    ],
     regimes: pd.Series,
     entry_thresholds: Iterable[float],
     exit_thresholds: Iterable[float],
@@ -22,8 +57,10 @@ def grid_search(
     ----------
     prices : pd.DataFrame
         Price data for the assets in each pair.
-    signals : dict
-        Mapping of pair tuples to DataFrame signals.
+    signal_func : callable
+        Function used to generate signals. It should accept ``prices``,
+        ``regimes``, ``entry_threshold``, ``exit_threshold`` and ``stop_loss_k``
+        and return a mapping of pair tuples to signal DataFrames.
     regimes : pd.Series
         Regime series used by the backtester.
     entry_thresholds, exit_thresholds, stop_loss_ks : iterable of float
@@ -51,7 +88,10 @@ def grid_search(
             stop_loss_k=sl_k,
         )
         bt = PairsBacktest(cfg)
-        bt.run_backtest(prices, signals, regimes)
+        generated_signals = signal_func(
+            prices, regimes, entry_t, exit_t, sl_k
+        )
+        bt.run_backtest(prices, generated_signals, regimes)
         metrics = bt.get_performance_metrics()
         metrics.update(
             {


### PR DESCRIPTION
## Summary
- make grid_search dynamically generate signals for each parameter set
- create a simple signal generator based on z-score
- test that grid search reacts to different parameters

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684adace47e08332bc959cbfab1b3aef