### PR TITLE
Extend test package warnings

### DIFF
--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -5,7 +5,7 @@ export PYTHONPATH="$ROOT_DIR:$PYTHONPATH"
 
 # Warn if key packages are missing
 missing=()
-for pkg in hmmlearn pykalman; do
+for pkg in hmmlearn pykalman pandas numpy; do
     python - <<EOF
 import importlib.util, sys
 sys.exit(0 if importlib.util.find_spec("$pkg") else 1)


### PR DESCRIPTION
## Summary
- warn about pandas and numpy in test runner

## Testing
- `scripts/run_tests.sh` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684ae089d904833287d0b156d2f01438