### PR TITLE
Add grid search CLI mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,20 @@ Optional flags include:
 
 - `--config PATH` - path to the configuration file (defaults to `config.yaml`)
 
+### Parameter Grid Search
+
+To evaluate different threshold combinations, run the grid search mode:
+
+```bash
+python run_engine.py --mode grid-search \
+    --entry-thresholds 1.5,2.0 \
+    --exit-thresholds 0.1 \
+    --stop-loss-ks 2.0
+```
+
+Ranges may also be specified in the `grid_search` section of `config.yaml`.
+Results are printed and saved to `grid_search_results.csv`.
+
 Running the engine will:
 1. Fetch ETF data
 2. Detect market regimes

--- a/config.yaml
+++ b/config.yaml
@@ -93,3 +93,9 @@ backtest:
   stop_loss_k: 2.0
   zscore_entry_threshold: 2.0
   zscore_exit_threshold: 0.1
+
+# Parameter ranges for CLI grid search
+grid_search:
+  entry_thresholds: [1.5, 2.0]
+  exit_thresholds: [0.1]
+  stop_loss_ks: [2.0]


### PR DESCRIPTION
## Summary
- support grid-search execution mode in `run_engine.py`
- document grid search usage in `README`
- expose grid search ranges in `config.yaml`

## Testing
- `./scripts/run_tests.sh` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684af29646808332955627eeb6468f75