### PR TITLE
Add grid-search CLI and clean README

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,20 @@ Running the engine will:
 4. Run the backtest
 5. Generate performance reports and visualizations
 
+### Grid Search
+
+Use `grid_search_cli.py` to explore parameter values for a single pair:
+
+```bash
+python grid_search_cli.py --config config.yaml \
+    --entry-range 1.5 2.0 2.5 \
+    --exit-range 0.1 0.2 \
+    --stop-range 2.0
+```
+
+The command fetches price data, runs the optimization and prints a table of
+results sorted by Sharpe ratio.
+
 ## Project Structure
 
 ```
@@ -108,25 +122,6 @@ All parameters are stored in `config.yaml`, which is read at runtime by
 `config.load_config()`. Edit this file to tweak tickers, thresholds and other
 settings.
 
-`CROSSVAL_TRAIN_DAYS` and `CROSSVAL_TEST_DAYS` control the size of the rolling
-training and testing windows used in `run_engine.py`. The engine trains models
-on the most recent `CROSSVAL_TRAIN_DAYS` of data, evaluates on the following
-`CROSSVAL_TEST_DAYS`, then advances the window by the test period length to
-create the next fold.
-
-Example snippet:
-
-```yaml
-ETF_TICKERS:
-  - XOM
-  - CVX
-CROSSVAL_TRAIN_DAYS: 252  # one year of training
-CROSSVAL_TEST_DAYS: 63    # three months of testing
-PAIR_PARAMS:
-  XOM_CVX:
-    entry_threshold: 1.8
-    exit_threshold: 0.6
-```
 
 ## Pair Scoring
 

--- a/grid_search_cli.py
+++ b/grid_search_cli.py
@@ -1,0 +1,65 @@
+import argparse
+import logging
+import pandas as pd
+
+from config import load_config
+from data.fetch_data import fetch_etf_data, DataFetchError
+from optimization.grid_search import grid_search, generate_signals
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run parameter grid search")
+    parser.add_argument(
+        "--config", default="config.yaml", help="Path to configuration file"
+    )
+    parser.add_argument(
+        "--entry-range", nargs="+", type=float, default=[1.5, 2.0, 2.5],
+        help="Entry threshold values"
+    )
+    parser.add_argument(
+        "--exit-range", nargs="+", type=float, default=[0.1, 0.2],
+        help="Exit threshold values"
+    )
+    parser.add_argument(
+        "--stop-range", nargs="+", type=float, default=[2.0],
+        help="Stop loss multipliers"
+    )
+    args = parser.parse_args()
+
+    cfg = load_config(args.config)
+    pair_list = cfg.get("MANUAL_PAIR_LIST")
+    if pair_list:
+        asset1, asset2 = pair_list[0]
+    else:
+        asset1, asset2 = cfg["ETF_TICKERS"][:2]
+
+    logger.info("Fetching data for %s and %s", asset1, asset2)
+    try:
+        prices = fetch_etf_data([asset1, asset2], cfg["START_DATE"], cfg["END_DATE"]).dropna()
+    except DataFetchError as e:
+        logger.error("Data fetch failed: %s", e)
+        return
+
+    regimes = pd.Series(index=prices.index, data=0)
+
+    results = grid_search(
+        prices,
+        generate_signals,
+        regimes,
+        entry_thresholds=args.entry_range,
+        exit_thresholds=args.exit_range,
+        stop_loss_ks=args.stop_range,
+        base_config=cfg["backtest"],
+    )
+
+    if results.empty:
+        logger.warning("Grid search produced no results")
+    else:
+        print(results.to_string(index=False))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- remove references to cross-validation parameters
- document the grid-search helper command
- provide a basic `grid_search_cli.py` utility

## Testing
- `./scripts/run_tests.sh` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684af2983be883328636bc1678706d2e