### PR TITLE
Fix tuple deletion in close_trade and add tests

### DIFF
--- a/backtest/backtest.py
+++ b/backtest/backtest.py
@@ -551,9 +551,9 @@ class PairsBacktest:
         else:
             self.equity_curve.loc[date] = float(self.config.initial_capital) + float(daily_pnl)
 
-        del self.positions[tuple(trade.asset1, trade.asset2)]
+        del self.positions[(trade.asset1, trade.asset2)]
         logger.info(
-            f"Closed position in {tuple(trade.asset1, trade.asset2)} at {date} with P&L: ${trade.pnl:,.2f}"
+            f"Closed position in {(trade.asset1, trade.asset2)} at {date} with P&L: ${trade.pnl:,.2f}"
         )
 
     def open_trade(self, pair: Tuple[str, str], date: pd.Timestamp, 

--- a/tests/test_pnl.py
+++ b/tests/test_pnl.py
@@ -133,3 +133,30 @@ def test_update_positions_uses_trade_stop_loss_k():
 
     bt._update_positions(dates[20], prices.loc[dates[20]])
     assert ("A", "B") in bt.positions
+
+
+def test_close_trade_removes_position():
+    bt = make_backtester()
+    date = datetime.datetime(2023, 1, 2)
+    prices = pd.DataFrame(
+        {
+            "A": [105.0],
+            "B": [90.0],
+        },
+        index=[date],
+    )
+    bt.prices = prices
+    bt.realized_pnl = pd.Series(index=prices.index, data=0.0)
+    bt.equity_curve = pd.Series(index=prices.index, data=bt.config.initial_capital)
+
+    trade = make_trade(
+        exit_date=None,
+        exit_price1=None,
+        exit_price2=None,
+        entry_price1=100.0,
+        entry_price2=95.0,
+    )
+    bt.positions[("A", "B")] = trade
+
+    bt.close_trade(trade, date)
+    assert ("A", "B") not in bt.positions


### PR DESCRIPTION
## Summary
- fix `close_trade` to delete position using a tuple key
- update log message for closing trades
- add unit test to ensure trades close without errors

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685029cb2e20833287152775952b2500