### PR TITLE
Fix rebalance active check

### DIFF
--- a/backtest/backtest.py
+++ b/backtest/backtest.py
@@ -33,6 +33,11 @@ class Trade:
     entry_regime: Optional[int] = None
     stop_loss_k: float = 2.0
 
+    @property
+    def is_active(self) -> bool:
+        """Return True if the trade has not been exited."""
+        return self.exit_date is None
+
 @dataclass
 class BacktestConfig:
     """Configuration parameters for backtesting."""
@@ -332,7 +337,8 @@ class PairsBacktest:
     def rebalance_positions(self, date):
         """Rebalance positions to maintain target volatility."""
         if self.last_rebalance is None or (date - self.last_rebalance).days >= self.rebalance_freq:
-            active_positions = [p for p in self.positions.values() if p.is_active]
+            # Only consider positions that are still open
+            active_positions = [p for p in self.positions.values() if p.exit_date is None]
             if not active_positions:
                 return
             

--- a/tests/test_pnl.py
+++ b/tests/test_pnl.py
@@ -133,3 +133,20 @@ def test_update_positions_uses_trade_stop_loss_k():
 
     bt._update_positions(dates[20], prices.loc[dates[20]])
     assert ("A", "B") in bt.positions
+
+
+def test_rebalance_positions_runs_without_attribute_error():
+    bt = make_backtester()
+    dates = pd.date_range("2023-01-01", periods=30)
+    bt.daily_returns = pd.Series(0.0, index=dates)
+
+    trade = make_trade(
+        entry_date=dates[0],
+        exit_date=None,
+        exit_price1=None,
+        exit_price2=None,
+    )
+    bt.positions[("A", "B")] = trade
+
+    # Should not raise AttributeError even if Trade lacks is_active attribute
+    bt.rebalance_positions(dates[-1])


### PR DESCRIPTION
## Summary
- track active trades via an `is_active` property on `Trade`
- avoid referencing missing attribute in `rebalance_positions`
- test that `rebalance_positions` runs without errors

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for pandas and numpy)*

------
https://chatgpt.com/codex/tasks/task_e_685029d4fd348332b9ca745d3d68ca70