### PR TITLE
Fix utils line

### DIFF
--- a/utils/data_utils.py
+++ b/utils/data_utils.py
@@ -24,4 +24,4 @@ def generate_walkforward_windows(
             break
         windows.append((train_start, train_end, test_start, test_end))
         current_start = current_start + pd.DateOffset(months=step_months)
-    return windows 
+    return windows


### PR DESCRIPTION
## Summary
- clean up the last line of `generate_walkforward_windows`

## Testing
- `./scripts/run_tests.sh` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6850222681448332b95e01e6bb5d8f32