### PR TITLE
Fix backtest config loading

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -58,8 +58,9 @@ class Config:
             # Extract pair selection config
             pair_selection = PairSelectionConfig(**config_dict.get('PAIR_SELECTION', {}))
             
-            # Extract backtest config
-            backtest = BacktestConfig(**config_dict.get('BACKTEST', {}))
+            # Extract backtest config from lowercase key to match config.yaml
+            backtest_cfg = config_dict.get('backtest', {}) or {}
+            backtest = BacktestConfig(**backtest_cfg)
             
             # Create main config
             return cls(


### PR DESCRIPTION
## Summary
- match config.yaml by reading `backtest` key

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68517daa2b90833288e5d3b892f4e9bd