### PR TITLE
Fix trade metrics when no trades

### DIFF
--- a/core/metrics.py
+++ b/core/metrics.py
@@ -102,7 +102,16 @@ class MetricsCalculator:
         """Calculate trade-level metrics."""
         try:
             if not trades:
-                return {}
+                return {
+                    'total_trades': 0,
+                    'winning_trades': 0,
+                    'losing_trades': 0,
+                    'win_rate': 0.0,
+                    'avg_return': 0.0,
+                    'avg_win': 0.0,
+                    'avg_loss': 0.0,
+                    'profit_factor': 0.0,
+                }
             
             # Calculate trade returns
             trade_returns = []
@@ -112,7 +121,16 @@ class MetricsCalculator:
                     trade_returns.append(returns)
             
             if not trade_returns:
-                return {}
+                return {
+                    'total_trades': len(trades),
+                    'winning_trades': 0,
+                    'losing_trades': 0,
+                    'win_rate': 0.0,
+                    'avg_return': 0.0,
+                    'avg_win': 0.0,
+                    'avg_loss': 0.0,
+                    'profit_factor': 0.0,
+                }
             
             # Calculate metrics
             trade_returns = np.array(trade_returns)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,19 @@
+import core.metrics as metrics
+
+class DummyConfig:
+    pass
+
+
+def test_calculate_trade_metrics_empty_trades():
+    calculator = metrics.MetricsCalculator(DummyConfig())
+    result = calculator._calculate_trade_metrics([])
+    assert result == {
+        'total_trades': 0,
+        'winning_trades': 0,
+        'losing_trades': 0,
+        'win_rate': 0.0,
+        'avg_return': 0.0,
+        'avg_win': 0.0,
+        'avg_loss': 0.0,
+        'profit_factor': 0.0,
+    }


### PR DESCRIPTION
## Summary
- handle division by zero in `MetricsCalculator._calculate_trade_metrics`
- add regression test for empty trade metrics

## Testing
- `pytest tests/test_metrics.py -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_68517f8893888332923d75b6f699b7b3