### PR TITLE
Implement walk-forward validation

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -108,9 +108,12 @@ ALLOWED_ENTRY_REGIMES: [0, 1]
 min_days_between_trades: 5
 
 # Walk-forward validation parameters
-WALKFORWARD_TRAIN_MONTHS: 18
-WALKFORWARD_TEST_MONTHS: 6
-WALKFORWARD_STEP_MONTHS: 6
+walkforward:
+  train_months: 24
+  test_months: 6
+  z_entry_values: [1.0, 1.5, 2.0]
+  z_exit_values: [0.5, 0.0]
+  scoring_metric: sharpe_ratio
 
 risk_management:
   # Stop-loss settings

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -2,12 +2,13 @@
 Core module for the mean reversion trading engine.
 """
 
-from .config import Config, PairSelectionConfig, BacktestConfig
+from .config import Config, PairSelectionConfig, BacktestConfig, WalkforwardConfig
 from .data_loader import DataLoader
 from .pair_selection import PairSelector
 from .backtest_runner import BacktestRunner
 from .metrics import MetricsCalculator
 from .plotting import PlotGenerator
+from .walkforward import WalkForwardValidator
 from .risk import compute_sector_exposure, max_drawdown
 from .cache import save_to_cache, load_from_cache
 
@@ -15,9 +16,11 @@ __all__ = [
     'Config',
     'PairSelectionConfig',
     'BacktestConfig',
+    'WalkforwardConfig',
     'DataLoader',
     'PairSelector',
     'BacktestRunner',
+    'WalkForwardValidator',
     'MetricsCalculator',
     'PlotGenerator',
     'compute_sector_exposure',

--- a/core/backtest_runner.py
+++ b/core/backtest_runner.py
@@ -16,7 +16,13 @@ class BacktestRunner:
         self.config = config
         self.logger = logging.getLogger(__name__)
 
-    def run_backtest(self, pair_data: pd.DataFrame, pair_metrics: Dict) -> Dict:
+    def run_backtest(
+        self,
+        pair_data: pd.DataFrame,
+        pair_metrics: Dict,
+        entry_threshold: Optional[float] = None,
+        exit_threshold: Optional[float] = None,
+    ) -> Dict:
         """
         Run backtest for a single pair.
         
@@ -41,8 +47,10 @@ class BacktestRunner:
             zscore = pair_metrics['zscore']
             
             # Calculate entry/exit thresholds
-            entry_threshold = self._calculate_entry_threshold(zscore)
-            exit_threshold = self._calculate_exit_threshold(zscore)
+            if entry_threshold is None:
+                entry_threshold = self._calculate_entry_threshold(zscore)
+            if exit_threshold is None:
+                exit_threshold = self._calculate_exit_threshold(zscore)
             
             # Run backtest
             position = 0

--- a/core/config.py
+++ b/core/config.py
@@ -50,6 +50,22 @@ class BacktestConfig:
         if self.allowed_entry_regimes is None:
             self.allowed_entry_regimes = ['mean_reverting', 'trending']
 
+
+@dataclass
+class WalkforwardConfig:
+    """Configuration for walk-forward validation parameters."""
+    train_months: int = 24
+    test_months: int = 6
+    z_entry_values: List[float] = None
+    z_exit_values: List[float] = None
+    scoring_metric: str = 'sharpe_ratio'
+
+    def __post_init__(self):
+        if self.z_entry_values is None:
+            self.z_entry_values = [1.0, 1.5, 2.0]
+        if self.z_exit_values is None:
+            self.z_exit_values = [0.5, 0.0]
+
 @dataclass
 class Config:
     """Main configuration class for the trading engine."""
@@ -58,6 +74,7 @@ class Config:
     end_date: str
     pair_selection: PairSelectionConfig
     backtest: BacktestConfig
+    walkforward: WalkforwardConfig
     pair_universes: Dict[str, Dict]
     pair_scoring: PairScoringConfig
     use_cache: bool = False
@@ -83,6 +100,10 @@ class Config:
             # Pair scoring weights
             pair_scoring_cfg = config_dict.get('pair_scoring', {})
             pair_scoring = PairScoringConfig(**pair_scoring_cfg)
+
+            # Walk-forward validation config
+            walkforward_cfg = config_dict.get('walkforward', {}) or {}
+            walkforward = WalkforwardConfig(**walkforward_cfg)
             
             # Create main config
             return cls(
@@ -91,6 +112,7 @@ class Config:
                 end_date=config_dict.get('END_DATE', ''),
                 pair_selection=pair_selection,
                 backtest=backtest,
+                walkforward=walkforward,
                 pair_universes=config_dict.get('PAIR_UNIVERSES', {}),
                 pair_scoring=pair_scoring,
                 use_cache=config_dict.get('use_cache', False),

--- a/core/walkforward.py
+++ b/core/walkforward.py
@@ -1,0 +1,105 @@
+"""Walk-forward validation module for adaptive signal tuning."""
+
+from typing import Dict, List, Tuple
+import pandas as pd
+import numpy as np
+import logging
+from dateutil.relativedelta import relativedelta
+
+
+class WalkForwardValidator:
+    """Perform walk-forward validation and adaptive threshold tuning."""
+
+    def __init__(self, config, data_loader, pair_selector, backtest_runner, metrics_calculator):
+        self.config = config
+        self.data_loader = data_loader
+        self.pair_selector = pair_selector
+        self.backtest_runner = backtest_runner
+        self.metrics_calculator = metrics_calculator
+        self.logger = logging.getLogger(__name__)
+
+    def _generate_folds(self) -> List[Tuple[pd.Timestamp, pd.Timestamp, pd.Timestamp]]:
+        start = pd.to_datetime(self.config.start_date)
+        end = pd.to_datetime(self.config.end_date)
+        train_months = self.config.walkforward.train_months
+        test_months = self.config.walkforward.test_months
+        folds = []
+        cur = start
+        while cur + relativedelta(months=train_months + test_months) <= end:
+            train_end = cur + relativedelta(months=train_months)
+            test_end = train_end + relativedelta(months=test_months)
+            folds.append((cur, train_end, test_end))
+            cur = cur + relativedelta(months=test_months)
+        return folds
+
+    def _tune_thresholds(self, pair: Tuple[str, str], train_data: pd.DataFrame) -> Tuple[float, float]:
+        """Grid search thresholds on training data."""
+        best_metric = -np.inf
+        best_entry = self.config.walkforward.z_entry_values[0]
+        best_exit = self.config.walkforward.z_exit_values[0]
+        pair_metrics = self.pair_selector.calculate_pair_metrics(train_data)
+        for entry in self.config.walkforward.z_entry_values:
+            for exit_ in self.config.walkforward.z_exit_values:
+                res = self.backtest_runner.run_backtest(
+                    train_data,
+                    pair_metrics,
+                    entry_threshold=entry,
+                    exit_threshold=exit_,
+                )
+                metric = res['metrics'].get(self.config.walkforward.scoring_metric, 0)
+                if metric > best_metric:
+                    best_metric = metric
+                    best_entry = entry
+                    best_exit = exit_
+        return best_entry, best_exit
+
+    def run(self, pairs: List[Tuple[str, str]]) -> List[Dict]:
+        """Run walk-forward validation for the given pairs."""
+        data = self.data_loader.data
+        folds = self._generate_folds()
+        all_fold_results = []
+        for i, (train_start, train_end, test_end) in enumerate(folds):
+            self.logger.info(f"Fold {i+1}: {train_start.date()} to {test_end.date()}")
+            train_slice = data.loc[train_start:train_end]
+            test_slice = data.loc[train_end:test_end]
+            fold_results = {}
+            for pair in pairs:
+                pair_train = train_slice[list(pair)].dropna()
+                pair_test = test_slice[list(pair)].dropna()
+                if pair_train.empty or pair_test.empty:
+                    continue
+                entry, exit_ = self._tune_thresholds(pair, pair_train)
+                pair_metrics = self.pair_selector.calculate_pair_metrics(pd.concat([pair_train, pair_test]))
+                result = self.backtest_runner.run_backtest(
+                    pair_test,
+                    pair_metrics,
+                    entry_threshold=entry,
+                    exit_threshold=exit_,
+                )
+                fold_results[pair] = result
+            portfolio_metrics = self.metrics_calculator.calculate_portfolio_metrics(fold_results)
+            all_fold_results.append({'results': fold_results, 'metrics': portfolio_metrics})
+        return all_fold_results
+
+    def aggregate(self, fold_results: List[Dict]) -> Dict:
+        """Aggregate equity curves and compute full-period metrics."""
+        combined = pd.Series(dtype=float)
+        for fold in fold_results:
+            if not fold['results']:
+                continue
+            eq = pd.DataFrame({p: r['equity'] for p, r in fold['results'].items()}).sum(axis=1)
+            combined = pd.concat([combined, eq])
+        if combined.empty:
+            return {}
+        combined = combined.sort_index()
+        returns = combined.pct_change().dropna()
+        total_return = (combined.iloc[-1] / combined.iloc[0]) - 1
+        cagr = (1 + total_return) ** (252 / len(returns)) - 1
+        sharpe = np.sqrt(252) * returns.mean() / returns.std()
+        drawdown = (combined / combined.cummax() - 1).min()
+        return {
+            'equity_curve': combined,
+            'cagr': cagr,
+            'sharpe_ratio': sharpe,
+            'max_drawdown': drawdown,
+        }


### PR DESCRIPTION
## Summary
- add `WalkforwardConfig` dataclass and load from YAML
- expose walk-forward validator through core package
- implement new `WalkForwardValidator` module
- allow `BacktestRunner.run_backtest` to accept fixed thresholds
- update example configuration with walk-forward parameters

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for pandas/numpy/yaml)*

------
https://chatgpt.com/codex/tasks/task_e_68518b69bd288332a6155badcf60303d