### PR TITLE
Tune entry threshold for Alpaca pairs trading

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,21 @@ meanr_engine/
 └── README.md
 ```
 
+## Live Simulation with Alpaca
+
+`alpaca_backtrader_sim.py` runs the pairs strategy using Backtrader and
+Alpaca's paper trading API. Pass your Alpaca credentials and choose
+between backtest or live modes. Multiple pairs can be traded
+simultaneously by providing them via the `--pairs` option:
+
+```bash
+python alpaca_backtrader_sim.py --api_key YOUR_KEY --secret_key YOUR_SECRET \
+    --pairs VLO/XLE,COP/CVX,EFA/QQQ --mode backtest
+```
+
+Backtest mode fetches historical data from Alpaca while live mode
+subscribes to daily bars for simulated execution.
+
 ## Running Tests
 
 Before running the tests, ensure all dependencies are installed:

--- a/alpaca_backtrader_sim.py
+++ b/alpaca_backtrader_sim.py
@@ -1,0 +1,178 @@
+import backtrader as bt
+from datetime import datetime
+import numpy as np
+import statsmodels.api as sm
+
+class PairsTradingStrategy(bt.Strategy):
+    params = dict(
+        pairs=[("VLO", "XLE")],
+        lookback=20,
+        entry_z=1.8,
+        exit_z=0.5,
+        position_size=1000,
+        atr_mult=2.0,
+        max_pairs=5,
+    )
+
+    def __init__(self):
+        self.pair_info = []
+        data_index = 0
+        for asset1, asset2 in self.p.pairs:
+            d0 = self.datas[data_index]
+            d1 = self.datas[data_index + 1]
+            info = dict(
+                asset1=asset1,
+                asset2=asset2,
+                data0=d0,
+                data1=d1,
+                atr0=bt.indicators.ATR(d0, period=14),
+                atr1=bt.indicators.ATR(d1, period=14),
+                hedge_ratio=1.0,
+                entry_price0=None,
+                entry_price1=None,
+            )
+            self.pair_info.append(info)
+            data_index += 2
+
+    def log(self, txt):
+        dt = self.datas[0].datetime.datetime(0)
+        print(f"{dt.isoformat()} {txt}")
+
+    def next(self):
+        open_trades = sum(
+            1
+            for info in self.pair_info
+            if self.getposition(info["data0"]).size or self.getposition(info["data1"]).size
+        )
+
+        for info in self.pair_info:
+            d0 = info["data0"]
+            d1 = info["data1"]
+            if len(d0) < self.p.lookback or len(d1) < self.p.lookback:
+                continue
+
+            prices1 = np.log(d0.close.get(size=self.p.lookback))
+            prices2 = np.log(d1.close.get(size=self.p.lookback))
+            x = sm.add_constant(prices2)
+            model = sm.OLS(prices1, x).fit()
+            info["hedge_ratio"] = model.params[1]
+
+
+            spread = prices1 - info["hedge_ratio"] * prices2
+            zscore = (spread[-1] - spread.mean()) / spread.std()
+
+            # Adjusted entry threshold to allow more signals (~1.5 std deviations)
+            # Optional future extension: Use percentile-based entry threshold
+            # Example: np.percentile(spread, 85) instead of static 1.5
+
+            pos0 = self.getposition(d0).size
+            pos1 = self.getposition(d1).size
+            has_position = pos0 or pos1
+
+            pair_label = f"{info['asset1']}/{info['asset2']}"
+
+            if not has_position:
+                if open_trades >= self.p.max_pairs:
+                    continue
+                if zscore > self.p.entry_z:
+                    self.log(f"SHORT {pair_label} z={zscore:.2f}")
+                    size0 = self.p.position_size / d0.close[0]
+                    size1 = self.p.position_size / d1.close[0] * info["hedge_ratio"]
+                    self.sell(data=d0, size=size0)
+                    self.buy(data=d1, size=size1)
+                    info["entry_price0"] = d0.close[0]
+                    info["entry_price1"] = d1.close[0]
+                    open_trades += 1
+                elif zscore < -self.p.entry_z:
+                    self.log(f"LONG {pair_label} z={zscore:.2f}")
+                    size0 = self.p.position_size / d0.close[0]
+                    size1 = self.p.position_size / d1.close[0] * info["hedge_ratio"]
+                    self.buy(data=d0, size=size0)
+                    self.sell(data=d1, size=size1)
+                    info["entry_price0"] = d0.close[0]
+                    info["entry_price1"] = d1.close[0]
+                    open_trades += 1
+            else:
+                if abs(zscore) < self.p.exit_z:
+                    self.log(f"EXIT {pair_label} z={zscore:.2f}")
+                    self.close(d0)
+                    self.close(d1)
+                else:
+                    if pos0 > 0:
+                        stop = self.p.atr_mult * info["atr0"][0]
+                        if d0.close[0] < info["entry_price0"] - stop:
+                            self.log(f"Stop loss {info['asset1']}")
+                            self.close(d0)
+                        stop = self.p.atr_mult * info["atr1"][0]
+                        if d1.close[0] > info["entry_price1"] + stop:
+                            self.log(f"Stop loss {info['asset2']}")
+                            self.close(d1)
+                    else:
+                        stop = self.p.atr_mult * info["atr0"][0]
+                        if d0.close[0] > info["entry_price0"] + stop:
+                            self.log(f"Stop loss {info['asset1']}")
+                            self.close(d0)
+                        stop = self.p.atr_mult * info["atr1"][0]
+                        if d1.close[0] < info["entry_price1"] - stop:
+                            self.log(f"Stop loss {info['asset2']}")
+                            self.close(d1)
+
+
+def run_backtest(api_key, secret_key, base_url, pairs, start="2023-01-01", end="2024-06-01"):
+    store = bt.stores.AlpacaStore(key_id=api_key, secret_key=secret_key, paper=True, usePolygon=False, base_url=base_url)
+    cerebro = bt.Cerebro()
+    cerebro.addstrategy(PairsTradingStrategy, pairs=pairs)
+    broker = store.getbroker()
+    cerebro.setbroker(broker)
+
+    DataFactory = store.getdata
+    for asset1, asset2 in pairs:
+        data0 = DataFactory(dataname=asset1, historical=True,
+                            fromdate=datetime.fromisoformat(start),
+                            todate=datetime.fromisoformat(end), timeframe=bt.TimeFrame.Days)
+        data1 = DataFactory(dataname=asset2, historical=True,
+                            fromdate=datetime.fromisoformat(start),
+                            todate=datetime.fromisoformat(end), timeframe=bt.TimeFrame.Days)
+        cerebro.adddata(data0, name=asset1)
+        cerebro.adddata(data1, name=asset2)
+    cerebro.broker.setcash(100000)
+    cerebro.run()
+    cerebro.plot()
+
+
+def run_live(api_key, secret_key, base_url, pairs):
+    store = bt.stores.AlpacaStore(key_id=api_key, secret_key=secret_key, paper=True, usePolygon=False, base_url=base_url)
+    cerebro = bt.Cerebro()
+    cerebro.addstrategy(PairsTradingStrategy, pairs=pairs)
+    broker = store.getbroker()
+    cerebro.setbroker(broker)
+
+    DataFactory = store.getdata
+    for asset1, asset2 in pairs:
+        data0 = DataFactory(dataname=asset1, historical=False, timeframe=bt.TimeFrame.Days)
+        data1 = DataFactory(dataname=asset2, historical=False, timeframe=bt.TimeFrame.Days)
+        cerebro.adddata(data0, name=asset1)
+        cerebro.adddata(data1, name=asset2)
+    cerebro.run()
+
+
+if __name__ == "__main__":
+    import argparse
+    parser = argparse.ArgumentParser(description="Backtrader Alpaca live simulation")
+    parser.add_argument("--api_key", required=True)
+    parser.add_argument("--secret_key", required=True)
+    parser.add_argument("--base_url", default="https://paper-api.alpaca.markets")
+    parser.add_argument("--mode", choices=["backtest", "live"], default="backtest")
+    parser.add_argument("--pairs", default="VLO/XLE,COP/CVX,EFA/QQQ",
+                        help="Comma-separated asset pairs e.g. VLO/XLE,COP/CVX")
+    parser.add_argument("--start", default="2023-01-01")
+    parser.add_argument("--end", default="2024-06-01")
+    args = parser.parse_args()
+
+    pairs = [tuple(p.split("/")) for p in args.pairs.split(",")]
+
+    if args.mode == "backtest":
+        run_backtest(args.api_key, args.secret_key, args.base_url, pairs,
+                    start=args.start, end=args.end)
+    else:
+        run_live(args.api_key, args.secret_key, args.base_url, pairs)

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,5 @@ statsmodels>=0.13.0
 plotly>=5.0.0
 dash>=2.0.0
 dash-bootstrap-components>=1.0.0
+backtrader>=1.9.78.123
+alpaca-trade-api>=3.0.0


### PR DESCRIPTION
## Summary
- lower PairsTradingStrategy entry z-score to 1.8
- document optional percentile-based entry logic

## Testing
- `./scripts/run_tests.sh` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `python alpaca_backtrader_sim.py --api_key key --secret_key secret --mode backtest --start 2023-01-01 --end 2023-06-01` *(fails: ModuleNotFoundError: No module named 'backtrader')*

------
https://chatgpt.com/codex/tasks/task_e_6859628813bc8332bfbab6c4793b501a