### PR TITLE
Implement transaction cost handling

### DIFF
--- a/core/backtest_runner.py
+++ b/core/backtest_runner.py
@@ -16,9 +16,14 @@ class BacktestRunner:
         self.config = config
         self.logger = logging.getLogger(__name__)
 
-    def _calculate_trade_pnl(self, position: int, entry_price: float, exit_price: float, 
+    def _calculate_trade_pnl(self, position: int, entry_price: float, exit_price: float,
                            current_prices: pd.Series, hedge_ratio: float) -> float:
-        """Calculate the actual PnL for a trade with proper position sizing."""
+        """Calculate the actual PnL for a trade with proper position sizing.
+
+        Transaction costs (slippage + commission) are applied using the
+        ``slippage_bps`` and ``commission_bps`` values from the backtest
+        configuration.  Costs are based on the notional value traded.
+        """
         position_size_pct = getattr(self.config.backtest, 'position_size_pct', 0.05)
         position_size_dollars = self.config.backtest.initial_capital * position_size_pct
         
@@ -34,8 +39,16 @@ class BacktestRunner:
         # Use the smaller share count to ensure we don't exceed position size
         shares = min(asset1_shares, asset2_shares)
         
-        # Calculate PnL with proper position sizing
+        # Calculate raw PnL with proper position sizing
         pnl = position * shares * (exit_price - entry_price)
+
+        # Apply transaction costs (round trip)
+        slippage_bps = getattr(self.config.backtest, 'slippage_bps', 0.0)
+        commission_bps = getattr(self.config.backtest, 'commission_bps', 0.0)
+        cost_pct = (slippage_bps + commission_bps) / 10000
+        notional = (abs(entry_price) + abs(exit_price)) * shares
+        pnl -= notional * cost_pct
+
         return pnl
 
     def run_backtest(

--- a/tests/test_backtest_runner.py
+++ b/tests/test_backtest_runner.py
@@ -1,0 +1,26 @@
+import pandas as pd
+from core.backtest_runner import BacktestRunner
+
+class DummyBacktestCfg:
+    def __init__(self):
+        self.initial_capital = 100000
+        self.position_size_pct = 0.1
+        self.slippage_bps = 1.0
+        self.commission_bps = 0.5
+
+class DummyConfig:
+    def __init__(self):
+        self.backtest = DummyBacktestCfg()
+
+
+def test_calculate_trade_pnl_with_costs():
+    runner = BacktestRunner(DummyConfig())
+    prices = pd.Series({'asset1': 100.0, 'asset2': 95.0})
+    pnl = runner._calculate_trade_pnl(1, 10.0, 12.0, prices, hedge_ratio=1.0)
+
+    shares = 50.0  # 100000 * 0.1 = 10000 -> min(10000/(2*100), (10000)/(2*95))
+    cost_pct = (1.0 + 0.5) / 10000
+    expected_cost = (10.0 + 12.0) * shares * cost_pct
+    expected = 1 * shares * (12.0 - 10.0) - expected_cost
+
+    assert abs(pnl - expected) < 1e-6


### PR DESCRIPTION
## Summary
- handle slippage and commissions in `BacktestRunner._calculate_trade_pnl`
- add unit test covering transaction cost calculation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for pandas, yaml, etc.)*
- `pip install -r requirements.txt` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686e7c6deffc8332abe6b64e4e54fabf